### PR TITLE
PPO_transitionSample -> drail.py에서 expert_n_states 추가

### DIFF
--- a/DiffATP/discrim_test.py
+++ b/DiffATP/discrim_test.py
@@ -1,0 +1,32 @@
+import os
+import sys
+sys.path.insert(0, "./")
+
+import torch
+from rlf.algos.il.base_il import BaseILAlgo
+from drail.drail import DRAILDiscrim
+import os
+
+class DummyArgs:
+    def __init__(self):
+        self.traj_load_path = "/home/imitation/DRAIL/data/traj/Walker2d-v3/0304/34-W-1-08-ppo/trajs.pt"  
+        self.traj_batch_size = 64
+        self.traj_frac = 1.0
+        self.traj_val_ratio = 0.0
+        self.device = "cuda" if torch.cuda.is_available() else "cpu"
+        self.cwd = os.getcwd()  # 현재 디렉토리 사용
+        self.traj_viz = False
+
+args = DummyArgs()
+drail_discrim = DRAILDiscrim()
+drail_discrim._load_expert_data(None, args)  # 전문가 데이터 로드
+
+for expert_batch in drail_discrim.expert_train_loader:
+    if 'next_state' in expert_batch:
+        print(f"next_state Shape: {expert_batch['next_state'].shape}")
+        print(f" state Shape: {expert_batch['state'].shape}")
+        print(f"next_state Shape: {expert_batch['next_state']}")
+        print(f" state Shape: {expert_batch['state']}")
+    else:
+        print("expert_batch에 next_state 없음")
+    break  #

--- a/drail/drail.py
+++ b/drail/drail.py
@@ -269,6 +269,9 @@ class DRAILDiscrim(BaseIRLAlgo):
         expert_actions = self._adjust_action(expert_actions)
         expert_states = self._norm_expert_state(expert_batch['state'],
                 obsfilt)
+        # next_state 추가 
+        expert_n_states = self._norm_expert_state(expert_batch['next_state'], obsfilt)  
+
         
         agent_states = self._trans_agent_state(agent_batch['state'],
                 agent_batch['other_state'] if 'other_state' in agent_batch else None)

--- a/rl-toolkit/rlf/rl/runner.py
+++ b/rl-toolkit/rlf/rl/runner.py
@@ -322,7 +322,7 @@ class Runner:
         if self.args.alg == 'dpf-deep' or self.args.alg == 'dpf':
             self.updater.modules[0].prox_func.load_state_dict(self.checkpointer.get_key("prox_func"))
         else:
-            if self.args.alg != 'bc' and self.args.alg != 'sac' and self.args.alg != 'dp' and self.args.alg != 'ppo':
+             if self.args.alg != 'bc' and self.args.alg != 'sac' and self.args.alg != 'dp' and self.args.alg != 'ppo'  and self.args.alg != 'PPO_sample':
                 self.updater.modules[0].discrim_net.load_state_dict(self.checkpointer.get_key("discrim_net"))
 
         if self.checkpointer.has_load_key("ob_rms"):


### PR DESCRIPTION
- transitionSample 클래스를 생성해서 (s,a,s') 형태의 데모 데이터를 리턴하여 사용하려고 했음 
- 모든 데이터가 Trajs.pt로 저장되고 (s,a,done,s') 구성의 dict 형태로 포함되어있음 
- drail/drail.py에서 expert_batch에서 [next_state]를 불러오도록 수정 